### PR TITLE
Readme: remove $ from example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -131,7 +131,7 @@ Assert that the table has timestamp columns.
 **Usage:**
 
 ```php
-	$this->$table->hasTimestamps();
+	$this->table->hasTimestamps();
 ```
 
 **Returns:** `EGALL\EloquentPHPUnit\Database\Table`


### PR DESCRIPTION
I noticed when viewing your readme (actually on packagist) that the `hasTimestamps()` example had a superfluous `$` that didn't appear to be correct, based on the other examples. 
